### PR TITLE
Show [FAKE] after the name of a token if use registered names

### DIFF
--- a/lib/erc20.js
+++ b/lib/erc20.js
@@ -95,6 +95,22 @@ Erc20Controller.prototype.getInfo = function(req, res) {
             return self.common.handleErrors(err, res);
         }
 
+        if (returnData.contract.symbol == 'HTML' || (returnData.contract.symbol == 'SVM') || (returnData.contract.symbol == 'SVN') || (returnData.contract.symbol == 'HTMT')) {
+            return res.jsonp({
+            contract_address: returnData.contract.contract_address,
+            total_supply: returnData.contract.total_supply,
+            decimals: returnData.contract.decimals,
+            name: returnData.contract.name + " [FAKE]",
+            symbol: returnData.contract.symbol,
+            version: returnData.contract.version,
+            transfers_count: returnData.countTransfers,
+            holders_count: returnData.countHolders
+        });
+
+        }
+
+        else
+
         return res.jsonp({
             contract_address: returnData.contract.contract_address,
             total_supply: returnData.contract.total_supply,


### PR DESCRIPTION
Hello, this is a proposed update to show a [FAKE] text when a person create a token using official names like HTMLCOIN.

The result:

![selected-fake-token](https://user-images.githubusercontent.com/3827247/45105547-d9671180-b10a-11e8-9d44-fd60804c2479.png)

A video showing working:

[![TESTING THE EXPLORER UPDATED](https://img.youtube.com/vi/eFKGGF_aSc0/0.jpg)](https://www.youtube.com/watch?v=eFKGGF_aSc0)